### PR TITLE
Fix cache expiration time discrepancy in useEthereumData hook in ethUtils.ts

### DIFF
--- a/lib/ethUtils.ts
+++ b/lib/ethUtils.ts
@@ -6,7 +6,7 @@ interface IEthereumData {
     ethPrice: number | null;
 }
 
-const CACHE_EXPIRATION_MS = 10000; // Cache expiration time (30 sec)
+const CACHE_EXPIRATION_MS = 30000; // Cache expiration time (30 sec)
 
 let cache: IEthereumData & { timestamp: number | null } = {
     blockNumber: null,


### PR DESCRIPTION
In the `useEthereumData` hook, the comment mentioned that the cache expiration time is set to "30 seconds." However, the actual value of the constant `CACHE_EXPIRATION_MS` was set to `10000` milliseconds (10 seconds), which caused a mismatch between the comment and the code behavior.

I’ve updated the value of `CACHE_EXPIRATION_MS` to `30000` milliseconds (30 seconds) to align with the comment and expected functionality.