### PR TITLE
chore: fix for replacing all spaces in a string

### DIFF
--- a/lib/stringUtils.ts
+++ b/lib/stringUtils.ts
@@ -10,6 +10,6 @@ export function truncateWalletAddress(str: string) {
 }
 
 export function toKebabCase(str: string) {
-  return str.toLowerCase().replace(" ", "-");
+  return str.toLowerCase().replace(/ /g, "-");
 }
 


### PR DESCRIPTION
I’ve updated the function to ensure that all spaces in a string are replaced, not just the first one.

Previously, the regular expression was only targeting the first space, but now, with the global flag (`/ /g`), it correctly replaces every space in the string. 

This change makes the function work as expected for strings with multiple spaces.