### PR TITLE
fix spelling errors in code and comments

### DIFF
--- a/app/mint-teth/components/Mint.tsx
+++ b/app/mint-teth/components/Mint.tsx
@@ -416,7 +416,7 @@ export function Mint() {
 
       if (!txHash) {
         setDepositStatus(StepStatus.FAILED);
-        throw new Error("Failed to determine trasaction hash for the deposit");
+        throw new Error("Failed to determine transaction hash for the deposit");
       }
 
       setDepositTxHash(txHash);

--- a/app/mint-teth/hooks/useTokenTransfer.ts
+++ b/app/mint-teth/hooks/useTokenTransfer.ts
@@ -52,7 +52,7 @@ export function useTokenTransfer() {
           process.env.NEXT_PUBLIC_ECLIPSE_RPC || "",
         );
 
-        // Define paramaters
+        // Define parameters
         const destination = "ethereum";
         const recipient = evmWallet.address;
         const originToken = warpCore.tokens[1];

--- a/app/mint-tusd/components/Mint.tsx
+++ b/app/mint-tusd/components/Mint.tsx
@@ -419,7 +419,7 @@ export function Mint() {
 
       if (!txHash) {
         setDepositStatus(StepStatus.FAILED);
-        throw new Error("Failed to determine trasaction hash for the deposit");
+        throw new Error("Failed to determine transaction hash for the deposit");
       }
 
       setDepositTxHash(txHash);

--- a/app/mint-tusd/hooks/useTokenTransfer.ts
+++ b/app/mint-tusd/hooks/useTokenTransfer.ts
@@ -54,7 +54,7 @@ export function useTokenTransfer() {
           process.env.NEXT_PUBLIC_ECLIPSE_RPC || "",
         );
 
-        // Define paramaters
+        // Define parameters
         const destination = "ethereum";
         const recipient = evmWallet.address;
         const originToken = warpCore.tokens[0];


### PR DESCRIPTION
Hi devs, while reviewing the codebase I came across a few typos and decided to fix them

`trasaction` - `transaction` х2
`paramaters` - `parameters` х2

Let me know if anything needs to be adjusted