### PR TITLE
Pump gas limit for ClaimWithdraw v3

### DIFF
--- a/app/components/WithdrawDetails/index.tsx
+++ b/app/components/WithdrawDetails/index.tsx
@@ -214,7 +214,7 @@ export const WithdrawDetails: React.FC<TransactionDetailsProps> = ({
         functionName: "claimWithdraw",
         args: [message],
         account,
-        gas: BigInt(100_000), // Set a 100k gas limit for the claim transaction
+        gas: BigInt(250_000), // Set a 100k gas limit for the claim transaction
         value: BigInt(0),
         chain: isMainnet ? mainnet : sepolia,
       });


### PR DESCRIPTION
Gas requirement is larger for withdraw v3 since it also routes for the old withdrawal. The default value we put on is not enough, so it will fail the tx if the users don't change the gas limit on the wallet. We pump the gas limit on the UI suggestion.